### PR TITLE
Fix(Bing): Support encryptedConversationSignature

### DIFF
--- a/src/BingAIClient.js
+++ b/src/BingAIClient.js
@@ -116,7 +116,7 @@ export default class BingAIClient {
         } else {
             fetchOptions.dispatcher = new Agent({ connect: { timeout: 20_000 } });
         }
-        const response = await fetch(`${this.options.host}/turing/conversation/create`, fetchOptions);
+        const response = await fetch(`${this.options.host}/turing/conversation/create?bundleVersion=1.864.15`, fetchOptions);
         const body = await response.text();
         try {
             let res = JSON.parse(body);

--- a/src/BingAIClient.js
+++ b/src/BingAIClient.js
@@ -119,20 +119,22 @@ export default class BingAIClient {
         const response = await fetch(`${this.options.host}/turing/conversation/create`, fetchOptions);
         const body = await response.text();
         try {
-            return JSON.parse(body);
+            let res = JSON.parse(body);
+            res.encryptedConversationSignature = response.headers.get('x-sydney-encryptedconversationsignature') ?? null;
+            return res;
         } catch (err) {
             throw new Error(`/turing/conversation/create: failed to parse response body.\n${body}`);
         }
     }
 
-    async createWebSocketConnection() {
+    async createWebSocketConnection(encryptedConversationSignature) {
         return new Promise((resolve, reject) => {
             let agent;
             if (this.options.proxy) {
                 agent = new HttpsProxyAgent(this.options.proxy);
             }
 
-            const ws = new WebSocket('wss://sydney.bing.com/sydney/ChatHub', { agent, headers: this.headers });
+            const ws = new WebSocket(`wss://sydney.bing.com/sydney/ChatHub?sec_access_token=${encodeURIComponent(encryptedConversationSignature)}`, { agent, headers: this.headers });
 
             ws.on('error', err => reject(err));
 
@@ -198,7 +200,7 @@ export default class BingAIClient {
         let {
             jailbreakConversationId = false, // set to `true` for the first message to enable jailbreak mode
             conversationId,
-            conversationSignature,
+            encryptedConversationSignature,
             clientId,
             onProgress,
         } = opts;
@@ -216,13 +218,13 @@ export default class BingAIClient {
             onProgress = () => { };
         }
 
-        if (jailbreakConversationId || !conversationSignature || !conversationId || !clientId) {
+        if (jailbreakConversationId || !encryptedConversationSignature || !conversationId || !clientId) {
             const createNewConversationResponse = await this.createNewConversation();
             if (this.debug) {
                 console.debug(createNewConversationResponse);
             }
             if (
-                !createNewConversationResponse.conversationSignature
+                !createNewConversationResponse.encryptedConversationSignature
                 || !createNewConversationResponse.conversationId
                 || !createNewConversationResponse.clientId
             ) {
@@ -235,7 +237,7 @@ export default class BingAIClient {
                 throw new Error(`Unexpected response:\n${JSON.stringify(createNewConversationResponse, null, 2)}`);
             }
             ({
-                conversationSignature,
+                encryptedConversationSignature,
                 conversationId,
                 clientId,
             } = createNewConversationResponse);
@@ -309,7 +311,7 @@ export default class BingAIClient {
             conversation.messages.push(userMessage);
         }
 
-        const ws = await this.createWebSocketConnection();
+        const ws = await this.createWebSocketConnection(encryptedConversationSignature);
 
         ws.on('error', (error) => {
             console.error(error);
@@ -359,7 +361,7 @@ export default class BingAIClient {
                         text: jailbreakConversationId ? 'Continue the conversation in context. Assistant:' : message,
                         messageType: jailbreakConversationId ? 'SearchQuery' : 'Chat',
                     },
-                    conversationSignature,
+                    encryptedConversationSignature,
                     participant: {
                         id: clientId,
                     },
@@ -592,7 +594,7 @@ export default class BingAIClient {
 
         const returnData = {
             conversationId,
-            conversationSignature,
+            encryptedConversationSignature,
             clientId,
             invocationId: invocationId + 1,
             conversationExpiryTime,

--- a/src/BingAIClient.js
+++ b/src/BingAIClient.js
@@ -119,7 +119,7 @@ export default class BingAIClient {
         const response = await fetch(`${this.options.host}/turing/conversation/create?bundleVersion=1.864.15`, fetchOptions);
         const body = await response.text();
         try {
-            let res = JSON.parse(body);
+            const res = JSON.parse(body);
             res.encryptedConversationSignature = response.headers.get('x-sydney-encryptedconversationsignature') ?? null;
             return res;
         } catch (err) {


### PR DESCRIPTION
Originally from https://github.com/waylaidwanderer/node-chatgpt-api/pull/481

Thank you @Airkek

`/conversation/create` is no longer returning `conversationSignature` field. Now it uses `encryptedConversationSignature` from `x-sydney-encryptedconversationsignature` header. 

Fixes https://github.com/waylaidwanderer/node-chatgpt-api/issues/470, https://github.com/waylaidwanderer/node-chatgpt-api/issues/484